### PR TITLE
feat(vercel-local-postgres): define Vercel's version here in the config

### DIFF
--- a/vercel-local-postgres.json5
+++ b/vercel-local-postgres.json5
@@ -4,11 +4,13 @@
   packageRules: [
     // Disable updates to the postgres image, because we want to manually
     // control this to always match the version Vercel uses in production.
-    // https://vercel.com/docs/storage/vercel-postgres#existing-postgres-stores
     {
       "matchPackageNames": ["/postgres/"],
       "matchManagers": ["docker-compose"],
-      "enabled": false
+      
+      // This should match the version of Postgres that Vercel uses in production. See https://vercel.com/docs/storage/vercel-postgres#existing-postgres-stores
+      // "Alpine" is a lightweight distribution of Postgres. See https://stackoverflow.com/questions/62333176/docker-difference-postgres12-from-postgres12-alpine
+      "allowedVersions": "postgres:15-alpine",
     }
   ],
 }


### PR DESCRIPTION
Now users of this config don't have to worry about pinning the right version. Updating this config to match Vercel's version will automatically update the version in any repos using this config. Change once, update everywhere.