### PR TITLE
ci: harden renovate config validation, caching, and signed agent commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/setup-claude-worktree-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-node@v4
         with:
-          python-version: "3.x"
-      # Runs `pre-commit run --all-files`, validating every *.json5 via the
-      # renovate-config-validator hook in .pre-commit-config.yaml. The action caches
-      # ~/.cache/pre-commit (keyed on the config hash), so the bundled renovate install
-      # is reused across runs instead of re-downloaded.
-      - uses: pre-commit/action@v3.0.1
+          node-version-file: .nvmrc
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          # Caches the npm download + the extracted npx environment for the
+          # renovate validator (~300MB), so the heavy install runs once and is
+          # reused across runs. Keyed on .pre-commit-config.yaml, which pins the
+          # renovate version, so the cache only rebuilds when that version changes.
+          key: npm-renovate-${{ hashFiles('.pre-commit-config.yaml') }}
+          # On a version bump, seed from the previous cache so only the delta downloads.
+          restore-keys: npm-renovate-
+      # Validates every *.json5 one file at a time and prints a per-config status
+      # table plus failure details, using the renovate version pinned in
+      # .pre-commit-config.yaml (same as the local pre-commit hook).
+      - name: Validate Renovate configs
+        run: ./scripts/validate-renovate-configs.sh
 
   commitlint:
     if: github.event_name == 'pull_request'
@@ -36,6 +46,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          # commitlint has no lockfile to key on, so key on the Node version: the npx
+          # download is then reused across runs instead of re-fetched every time.
+          key: npm-commitlint-${{ hashFiles('.nvmrc') }}
+          restore-keys: npm-commitlint-
       - name: Lint commit messages
         run: npx --yes --package @commitlint/cli --package @commitlint/config-conventional -- commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 
+# Claude Code
+.claude/worktrees/
+

--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ pre-commit run --all-files
 ```
 
 
+# Agent commit signing
+
+`main` requires signed commits. When you run an agent (Claude Code, etc.) inside a
+`claude/*` worktree, `scripts/setup-claude-worktree-git.sh` configures a per-worktree
+identity that signs the agent's commits with a dedicated SSH key, authored as
+`Claude Code (<you>)` — without touching your personal git config on other branches.
+
+The one-time per-machine setup (SSH signing key, `~/.gitconfig.claude`, registering the
+key on GitHub) is shared with our other repos and documented in StoryCut's guide:
+<https://github.com/StoryCut/StoryCut/blob/main/docs/dev-guides/agents-signing.md>
+
+Once that's done, run the script in a `claude/*` worktree to apply it:
+```bash
+./scripts/setup-claude-worktree-git.sh
+```
+
+
 # Commands
 
 ## Validate a config locally

--- a/scripts/setup-claude-worktree-git.sh
+++ b/scripts/setup-claude-worktree-git.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# setup-claude-worktree-git.sh
+#
+# Configures a per-worktree git identity so that commits made by an agent
+# (Claude Code, Codex, etc.) inside a `claude/*` branch are authored as
+# "Claude Code (<contributor>)" and signed with a dedicated SSH key —
+# NOT with the human contributor's personal GPG key.
+#
+# Why per-worktree config (not includeIf in ~/.gitconfig)?
+#   The repo's local `.git/config` may set `user.signingkey` to the
+#   contributor's personal GPG key. Local config beats global config —
+#   including any `includeIf` rule in ~/.gitconfig. So an `includeIf`
+#   approach can override `user.name` and `user.email` but NOT
+#   `user.signingkey`. Per-worktree config (via `extensions.worktreeConfig`)
+#   sits ABOVE local config in git's precedence ladder, so it can
+#   actually override the signing key in just the Claude worktrees.
+#
+# Where the identity comes from:
+#   This script reads the contributor's Claude identity from
+#   ~/.gitconfig.claude (a regular git-config-format file). Each
+#   contributor sets that file up once on their machine — see the
+#   "Agent commit signing" section in README.md (which points to
+#   StoryCut's full one-time setup guide).
+#
+# When this runs:
+#   - Automatically: SessionStart hook in .claude/settings.json fires
+#     this script every time an agent session starts in a Claude
+#     worktree. Idempotent — safe to run repeatedly.
+#   - Manually: invoke it directly if you need to (re-)apply the
+#     identity without restarting the agent session.
+#
+# What this does NOT do:
+#   - Does not affect non-Claude branches (the `claude/*` check is at
+#     the top — exits early on `main`, `feature/...`, etc.).
+#   - Does not affect other repos (per-worktree config is scoped to
+#     this repo only).
+#   - Does not modify the human contributor's personal git config.
+
+set -euo pipefail
+
+# ---- 1. Bail early if not in a Claude worktree ----------------------------
+# Claude worktrees use the `claude/<name>` branch naming convention.
+# In any other branch (main, feature/*, dependabot/*, etc.) we want
+# the human contributor's normal git identity to apply.
+branch=$(git branch --show-current 2>/dev/null || true)
+if [[ "$branch" != claude/* ]]; then
+  exit 0
+fi
+
+# ---- 2. Bail if the contributor hasn't set up ~/.gitconfig.claude ---------
+# This is the per-contributor identity file. New contributors create it
+# once via the steps in the README's "Agent commit signing" section. If
+# it's missing, surface a friendly hint instead of failing silently.
+identity_file="$HOME/.gitconfig.claude"
+if [[ ! -f "$identity_file" ]]; then
+  echo "WARNING: $identity_file not found."
+  echo "Claude commit identity not configured for this worktree."
+  echo "See the 'Agent commit signing' section in README.md for the one-time setup."
+  exit 0
+fi
+
+# ---- 3. Enable extensions.worktreeConfig (one-time per repo) --------------
+# Per-worktree config files (.git/worktrees/<name>/config.worktree)
+# only take effect when this extension is enabled in the main repo
+# config. Idempotent — git short-circuits if it's already true.
+git config extensions.worktreeConfig true
+
+# ---- 4. Apply the Claude identity to this worktree's config ---------------
+# Each setting is copied from ~/.gitconfig.claude into the worktree's
+# own config file. The worktree config beats local .git/config, so
+# this overrides the contributor's personal user.signingkey just for
+# commits made inside this worktree.
+#
+# Idempotent: only writes if the value differs from what's already
+# there, so re-runs are silent no-ops.
+keys=(
+  user.name
+  user.email
+  user.signingkey
+  gpg.format
+  gpg.ssh.allowedSignersFile
+  commit.gpgsign
+)
+
+changed=0
+for key in "${keys[@]}"; do
+  value=$(git config --file "$identity_file" --get "$key" 2>/dev/null || true)
+  [[ -z "$value" ]] && continue
+
+  current=$(git config --worktree --get "$key" 2>/dev/null || true)
+  if [[ "$current" != "$value" ]]; then
+    git config --worktree "$key" "$value"
+    changed=1
+  fi
+done
+
+if [[ $changed -eq 1 ]]; then
+  echo "✓ Claude commit identity configured for this worktree (branch: $branch)"
+fi

--- a/scripts/validate-renovate-configs.sh
+++ b/scripts/validate-renovate-configs.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Validate every Renovate config (*.json5) in the repo, one file at a time, and
+# print a per-config ASCII summary table. For any config that fails, print the
+# validator's explanation. Exits non-zero if any config fails.
+#
+# The renovate version is read from .pre-commit-config.yaml so CI and the local
+# pre-commit hook always validate with the exact same version. Runs in CI and
+# locally (`./scripts/validate-renovate-configs.sh`) — only Node is required.
+
+set -uo pipefail
+
+CONFIG_FILE=".pre-commit-config.yaml"
+
+# Single source of truth for the renovate version: the pinned rev of the
+# renovatebot/pre-commit-hooks repo, whose release tags mirror renovate's npm
+# versions (the hook bundles the matching renovate@<rev>).
+RENOVATE_VERSION=$(awk '
+  /renovatebot\/pre-commit-hooks/ { found = 1 }
+  found && /rev:/ { sub(/.*rev:[[:space:]]*/, ""); sub(/[[:space:]]+$/, ""); print; exit }
+' "$CONFIG_FILE")
+
+if [ -z "${RENOVATE_VERSION:-}" ]; then
+  echo "error: could not determine renovate version from $CONFIG_FILE" >&2
+  exit 1
+fi
+
+# Discover configs from git so newly added *.json5 files are picked up automatically.
+configs=()
+while IFS= read -r f; do
+  configs+=("$f")
+done < <(git ls-files '*.json5' | sort)
+
+if [ "${#configs[@]}" -eq 0 ]; then
+  echo "No *.json5 Renovate configs found."
+  exit 0
+fi
+
+# Validate one file as a repository config, in isolation. Each file is copied into an
+# empty temp dir as renovate.json5 (a name auto-discovery recognizes) and validated
+# there. This matters for two reasons:
+#   1. Passing a file as a positional arg makes the validator treat it as a *global*
+#      (admin) config — the wrong schema for these presets — and suppresses the error
+#      details for every failing file after the first.
+#   2. Validating in the repo root would also auto-discover the repo's own
+#      renovate.json5, so one broken config would make *every* file report FAIL.
+# Isolation gives the correct (repository) schema, full error details, and no cross-talk.
+# The temp filename in the output is rewritten back to the real name by the caller.
+validate() { # usage: validate <file>; prints validator output, returns its exit code
+  local tmp rc
+  tmp=$(mktemp -d)
+  cp "$1" "$tmp/renovate.json5"
+  ( cd "$tmp" && npx --yes --package "renovate@${RENOVATE_VERSION}" -- renovate-config-validator --strict 2>&1 )
+  rc=$?
+  rm -rf "$tmp"
+  return "$rc"
+}
+
+# Warm the npx environment once so the cold-run npm install logs don't get mixed
+# into a per-config result. (On a cache hit this is a no-op.)
+echo "Validating ${#configs[@]} Renovate config(s) with renovate@${RENOVATE_VERSION}..."
+validate "${configs[0]}" >/dev/null 2>&1 || true
+
+# Parallel, index-aligned arrays (kept bash 3.2-compatible for macOS).
+names=()
+statuses=()
+details=()
+overall=0
+
+i=0
+for f in "${configs[@]}"; do
+  # Capture once: the strict run already prints the failure reason, so the output
+  # doubles as the details for the failure report (no second invocation needed).
+  out=$(validate "$f")
+  rc=$?
+  names[i]="$f"
+  if [ "$rc" -eq 0 ]; then
+    statuses[i]="PASS"
+    details[i]=""
+  else
+    statuses[i]="FAIL"
+    overall=1
+    # Rewrite the temp name (renovate.json5) back to the real file for readability.
+    details[i]="${out//renovate.json5/$f}"
+  fi
+  i=$((i + 1))
+done
+
+# Column widths sized to the longest value.
+w_config=6 # len("Config")
+for n in "${names[@]}"; do [ "${#n}" -gt "$w_config" ] && w_config=${#n}; done
+w_status=6 # len("Status")
+
+dashes() { printf '%*s' "$1" '' | tr ' ' '-'; }
+sep="+-$(dashes "$w_config")-+-$(dashes "$w_status")-+"
+
+pass=0
+fail=0
+for s in "${statuses[@]}"; do
+  if [ "$s" = "PASS" ]; then pass=$((pass + 1)); else fail=$((fail + 1)); fi
+done
+
+printf '\nRenovate config validation\n'
+echo "$sep"
+printf "| %-*s | %-*s |\n" "$w_config" "Config" "$w_status" "Status"
+echo "$sep"
+for i in "${!names[@]}"; do
+  printf "| %-*s | %-*s |\n" "$w_config" "${names[i]}" "$w_status" "${statuses[i]}"
+done
+echo "$sep"
+printf '%d passed, %d failed, %d total\n' "$pass" "$fail" "${#names[@]}"
+
+if [ "$overall" -ne 0 ]; then
+  printf '\n===== Failure details =====\n'
+  for i in "${!names[@]}"; do
+    if [ "${statuses[i]}" = "FAIL" ]; then
+      printf '\n--- %s ---\n%s\n' "${names[i]}" "${details[i]}"
+    fi
+  done
+fi
+
+# Render the same summary into the GitHub Actions job summary (markdown).
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Renovate config validation"
+    echo
+    echo "Validated with \`renovate@${RENOVATE_VERSION}\`."
+    echo
+    echo "| Config | Status |"
+    echo "| --- | --- |"
+    for i in "${!names[@]}"; do
+      if [ "${statuses[i]}" = "PASS" ]; then icon="✅ PASS"; else icon="❌ FAIL"; fi
+      echo "| \`${names[i]}\` | ${icon} |"
+    done
+    echo
+    echo "**${pass} passed, ${fail} failed, ${#names[@]} total**"
+    if [ "$overall" -ne 0 ]; then
+      echo
+      for i in "${!names[@]}"; do
+        if [ "${statuses[i]}" = "FAIL" ]; then
+          echo "<details><summary>❌ ${names[i]}</summary>"
+          echo
+          echo '```'
+          echo "${details[i]}"
+          echo '```'
+          echo
+          echo "</details>"
+        fi
+      done
+    fi
+  } >>"$GITHUB_STEP_SUMMARY"
+fi
+
+exit "$overall"


### PR DESCRIPTION
## Summary

Follow-up to #42. Three related improvements to this repo's tooling.

### 1. Renovate validation: custom script with a result table (+ correctness fixes)
- Replaces the `pre-commit/action` step with `scripts/validate-renovate-configs.sh`, which validates every `*.json5` and prints a per-config **ASCII status table**, **failure details**, and a **GitHub job summary**. Renovate version comes from `.pre-commit-config.yaml`, so CI and the local hook stay in sync.
- Each config is validated in an **isolated temp dir** (copied in as `renovate.json5`), fixing two bugs in the path-arg approach: files were validated as *global* (admin) configs — the wrong schema — with error details suppressed for every failing file after the first; and a broken `renovate.json5` would have made *every* config falsely FAIL via auto-discovery.

### 2. Caching
- **`commitlint` job**: added `~/.npm` caching (was re-downloading commitlint every run).
- **`renovate-config` job**: added `restore-keys` so a renovate version bump downloads only the delta. (Confirmed effect: the job dropped from ~70s cold to ~38s on a warm cache.)
- GitHub Actions jobs run on isolated VMs and need different packages, so there's nothing to share between them in a run — cross-run `actions/cache` is the right lever, now on both jobs.

### 3. Signed agent commits
`main` requires signed commits. Adds `scripts/setup-claude-worktree-git.sh` + a `SessionStart` hook (`.claude/settings.json`) that configures a per-worktree identity so agent commits in `claude/*` worktrees are authored as `Claude Code (<you>)` and SSH-signed — without touching the human identity on other branches. README documents the shared one-time machine setup (pointing to StoryCut's guide). All commits in this PR are signed and GitHub-Verified.

## Test plan
- [x] Validator: all 7 configs PASS locally; a broken config shows `FAIL` + real error reasons in console and job summary; no cross-contamination.
- [x] Caching: `renovate-config` warm run ~38s vs ~70s cold.
- [x] Signing: all PR commits show `verified: true` via the GitHub API.
- [x] CI green (`renovate-config`, `commitlint`, Semantic PR).

## Manual follow-up
- None required — branch protection's "Require signed commits" is already satisfied by the verified commits here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)