### PR TITLE
chore: move config references to nunofyobiz org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# StoryCut/renovate-config
+# nunofyobiz/renovate-config
 
 Renovate configurations for this organization
 
-[![CI](https://github.com/StoryCut/renovate-config/actions/workflows/ci.yml/badge.svg)](https://github.com/StoryCut/renovate-config/actions/workflows/ci.yml)
+[![CI](https://github.com/nunofyobiz/renovate-config/actions/workflows/ci.yml/badge.svg)](https://github.com/nunofyobiz/renovate-config/actions/workflows/ci.yml)
 
 
 # Local setup

--- a/default.json5
+++ b/default.json5
@@ -7,6 +7,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
   extends: [
-    "github>StoryCut/renovate-config:js-app.json5",
+    "github>nunofyobiz/renovate-config:js-app.json5",
   ],
 }

--- a/js-app.json5
+++ b/js-app.json5
@@ -15,7 +15,7 @@
     // See https://docs.renovatebot.com/presets-config/#configjs-app
     "config:js-app",
 
-    "github>StoryCut/renovate-config:org.json5",
-    "github>StoryCut/renovate-config:js-base.json5",
+    "github>nunofyobiz/renovate-config:org.json5",
+    "github>nunofyobiz/renovate-config:js-base.json5",
   ],
 }

--- a/js-lib.json5
+++ b/js-lib.json5
@@ -15,7 +15,7 @@
     // See https://docs.renovatebot.com/presets-config/#configjs-lib
     "config:js-lib",
 
-    "github>StoryCut/renovate-config:org.json5",
-    "github>StoryCut/renovate-config:js-base.json5",
+    "github>nunofyobiz/renovate-config:org.json5",
+    "github>nunofyobiz/renovate-config:js-base.json5",
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,6 @@
 
   extends: [
     // This isn't a JS lib, but this config is still kind of what we want for this repo
-    "github>StoryCut/renovate-config:js-lib.json5",
+    "github>nunofyobiz/renovate-config:js-lib.json5",
   ],
 }


### PR DESCRIPTION
The renovate-config repo moved from the `StoryCut` org to `nunofyobiz`. This updates the repo's own self-referencing presets and docs to the new location.

- `js-lib.json5`, `js-app.json5`: `github>StoryCut/renovate-config:{org,js-base}.json5` → `nunofyobiz/...`
- `renovate.json5`: self-reference to `js-lib.json5` → `nunofyobiz/...`
- `default.json5`: self-reference to `js-app.json5` → `nunofyobiz/...`
- `README.md`: title + CI badge URLs → `nunofyobiz/renovate-config`

The `StoryCut/StoryCut` agents-signing doc link in the README is left as-is (the StoryCut app repo did not move).

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qrbp9fDuoPUeJCMUnLRhd)_