### PR TITLE
fix: never pin the engines field

### DIFF
--- a/js-lib.json5
+++ b/js-lib.json5
@@ -18,4 +18,23 @@
     "github>nunofyobiz/renovate-config:org.json5",
     "github>nunofyobiz/renovate-config:js-base.json5",
   ],
+
+  packageRules: [
+    /* ******************************************************
+     * SECTION: engines are floors, not pins
+     * A library's `engines.node` is a public contract — the runtime range its consumers must
+     * satisfy — so it's a deliberate floor, not a dependency to track. A repo-level
+     * `rangeStrategy: "pin"` would pin it to the latest release, silently raising the support floor
+     * and making pnpm throw ERR_PNPM_UNSUPPORTED_ENGINE when the running node can't satisfy the
+     * pinned value. Never let Renovate touch engines; the floor moves by hand. `enabled: false`
+     * (not a `rangeStrategy`) so a downstream repo-level `pin` rule can't re-enable it. This lives
+     * in js-lib (not js-base) because engines floors are a library concern — apps don't declare
+     * `engines.node`, so js-app just uses Renovate's defaults. The package-manager version is pinned
+     * only in `packageManager` (still Renovate-managed) — there is deliberately no `engines.pnpm`.
+     ****************************************************** */
+    {
+      matchDepTypes: ["engines"],
+      enabled: false,
+    },
+  ],
 }


### PR DESCRIPTION
## Problem

A library's `engines.node` is a **public contract** — the runtime range its consumers must satisfy — so it's a deliberate floor, not a dependency to track. But `config:js-app` (and any repo-level `rangeStrategy: "pin"`) pins the `engines` depType to the latest release. That:

1. silently **raises the support floor** with no human decision, and
2. **breaks installs**: pnpm checks the project's `engines` and throws `ERR_PNPM_UNSUPPORTED_ENGINE` when the running node can't satisfy the pinned value.

This just bit projitect — Renovate pinned `engines.node → "v26.3.0"` (and `engines.pnpm → "11.5.2"`) while the toolchain ran node 22–24 / pnpm 10.33.4, taking down its CI.

## Fix

Add a rule to **`js-lib.json5`** (not `js-base.json5`) disabling Renovate updates for the `engines` depType — engine floors move by hand:

```json5
{
  matchDepTypes: ["engines"],
  enabled: false,
},
```

**Why `js-lib`, not `js-base`:** `engines.node` is a library concern — the floor only matters because libraries are *consumed*. Apps have no consumers; their runtime is pinned by `.nvmrc` + the deploy platform, so they don't declare `engines.node` and `js-app` just uses Renovate's defaults.

`enabled: false` (rather than a `rangeStrategy`) is deliberate: packageRules merge in order, and a downstream repo's later `pin` rule sets only `rangeStrategy` — it can't flip `enabled` back to `true`, so the disable survives.

This does **not** touch the package-manager version: that stays pinned solely in `packageManager` (still Renovate-managed). There is deliberately no `engines.pnpm` to duplicate or contradict it.

## Verification

`renovate-config-validator --strict js-lib.json5` ✓ (and `js-base.json5` ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)