### PR TITLE
chore: tighten permission-prompt posture; allowlist git grep, echo, Kandev reads

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,8 @@
       "Bash(git fetch *)",
       "Bash(git log)",
       "Bash(git log *)",
+      "Bash(git grep)",
+      "Bash(git grep *)",
       "Bash(git mv *)",
       "Bash(git push)",
       "Bash(git push -u *)",
@@ -49,6 +51,7 @@
       "Bash(git show *)",
       "Bash(git ls-tree *)",
       "Bash(git ls-remote *)",
+      "Bash(git check-ignore)",
       "Bash(git check-ignore *)",
       "Bash(git remote -v)",
       "Bash(git remote show *)",
@@ -97,12 +100,21 @@
       "Bash(sed *)",
       "Bash(rg)",
       "Bash(rg *)",
+      "Bash(grep)",
+      "Bash(grep *)",
+      "Bash(echo)",
+      "Bash(echo *)",
       "Bash(head *)",
       "Bash(tail *)",
       "Bash(wc)",
       "Bash(wc *)",
       "Bash(node --version)",
-      "Bash(command -v *)"
+      "Bash(command -v *)",
+      "mcp__kandev__list_workspaces_kandev",
+      "mcp__kandev__list_workflows_kandev",
+      "mcp__kandev__list_workflow_steps_kandev",
+      "mcp__kandev__list_tasks_kandev",
+      "mcp__kandev__move_task_kandev"
     ]
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,11 +37,21 @@ auto-approves a command only when *every* part of it is independently safe, so s
 an otherwise-allowlisted command. The allowlist in [`.claude/settings.json`](./.claude/settings.json)
 covers the safe reads and the validator script; you keep prompts low by *how* you invoke things:
 
-- **Prefer the built-in `Grep` / `Glob` / `Read` tools** over shell `grep` / `find` / `cat` and
-  pipelines. They don't go through the Bash permission path, so they never prompt — and they're faster.
-- **One command per tool call — never `&&` / `;` / `|` chains.** A compound line is auto-approved only
-  if every segment independently clears, so even an all-allowlisted chain (`git add … && git commit …
-  && git log …`) prompts. Run the steps as separate calls.
+- **Prefer the built-in `Grep` / `Glob` / `Read` tools** over shell `grep` / `git grep` / `find` /
+  `cat` / `sed` / `head` and pipelines. They don't go through the Bash permission path, so they never
+  prompt — and they're faster. Concretely:
+  - `sed -n 'A,Bp' file` / `head -n N file` → `Read` with `offset` / `limit`.
+  - `grep … file` / `git grep …` → the `Grep` tool. Scope with `glob` (e.g. `**/*.json5`) and exclude
+    paths with a negated glob instead of a `| grep -v` pipe.
+  - **Reading or searching N files → one `Grep`/`Read`, never a `for f in …; do grep …; done` loop.**
+  - Drop `echo "=== … ==="` section separators and `|| echo "no matches"` fallbacks entirely — the
+    native tools label their output and report empty results for free. A stray `echo` is enough to
+    force a prompt on an otherwise-allowlisted block.
+- **One command per tool call — never `&&` / `;` / `|` / `$(…)` chains or `for`/`while` loops.** A
+  compound line is auto-approved only if every segment independently clears, so even an all-allowlisted
+  chain (`git add … && git commit … && git log …`) prompts. Run the steps as separate calls. Loops and
+  command substitution prompt structurally — reach for the native tools above instead of trying to
+  allowlist your way around it.
 - **Run the validator verbatim** — `bash scripts/validate-renovate-configs.sh`, with no env-var prefix
   (`TMPDIR=…`) and no `2>&1 | tail` / `2>/dev/null` capture wrapper. Run it bare and read the output;
   the redirect/pipe is itself what prompts.


### PR DESCRIPTION
## What

Brings this repo's agent permission posture in line with the StoryCut/sibling baseline:

1. **`AGENTS.md` › Permission-prompt posture** — enhances the existing section with the concrete native-tool mappings (`sed -n` / `head` → `Read` offset/limit; `grep` / `git grep` → the `Grep` tool with a `glob`, e.g. `**/*.json5`), the "one `Grep`, not a `for` loop" guidance, the `echo`-separator / `|| echo` fallback warning, and the no-`$(…)`/no-loops note.
2. **`.claude/settings.json`** — allowlists:
   - `grep`, `git grep`, and `echo` — all individually inert, but a stray `echo "=== … ==="` separator defeats an otherwise-allowlisted compound, since the engine only auto-approves when **every** segment clears.
   - The five approved **Kandev MCP** tools: `list_workspaces`, `list_workflows`, `list_workflow_steps`, `list_tasks` (read-only), plus the reversible `move_task`. Enumerated, **not** a blanket `mcp__kandev__*`.

## Scope

Read-only/non-destructive only. Loops, command substitution, pipes, chains, bare `npx`, `gh pr merge`, and destructive git stay gated by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
